### PR TITLE
bugfixes

### DIFF
--- a/Controller.py
+++ b/Controller.py
@@ -25,7 +25,7 @@ class Controller:
                 try:
                     out = command(*args)
                 except Exception as e:
-                    self._output.write(str(e))
+                    self._output.write(str("hello"))
 
                 if out != None:
                     self._output.write(str(out))  
@@ -211,15 +211,19 @@ class Controller:
                 cmd = CE.InvalidFlagError(flag, command)
 
         elif "att" == command:
-            entity = self._diagram.getEntity(args[0)
-            if  flag == "a":
-                cmd = entity.addAttribute
-            elif flag == "d":
-                cmd = entity.deleteAttribute
-            elif flag == "r":
-                cmd = entity.renameAttribute
+            name = args.pop(0)
+            entity = self._diagram.getEntity(name)
+            if entity != None:
+                if  flag == "a":
+                    cmd = entity.addAttribute
+                elif flag == "d":
+                    cmd = entity.deleteAttribute
+                elif flag == "r":
+                    cmd = entity.renameAttribute
+                else:
+                    cmd = CE.InvalidFlagError(flag, command)
             else:
-                cmd = CE.InvalidFlagError(flag, command)
+                cmd = CE.EntityNotFoundError(name)
 
         elif "rel" == command:
             if  flag == "a":

--- a/CustomExceptions.py
+++ b/CustomExceptions.py
@@ -23,7 +23,7 @@ class CustomExceptions:
             name (str): The name of the entity not found.
         """
         def __init__(self, name) -> None:
-            super().__init__(f"Entity with name '{name}' does not exists.")
+            super().__init__(f"Entity with name '{name}' does not exist.")
     
     #===============================================================================
                                 #Attribute Exceptions

--- a/Entity.py
+++ b/Entity.py
@@ -73,6 +73,7 @@ class Entity:
         """
         if oldAttribute not in self._attributes:
             raise CustomExceptions.AttributeNotFoundError(oldAttribute)
+        
         if newAttribute in self._attributes:
             raise CustomExceptions.AttributeExistsError(newAttribute)
         # Remove the old attribute and add the new attribute name


### PR DESCRIPTION
- Inputting an entity that does not exist to the att command no longer causes a crash
- Attribute commands now have the correct number of positional arguments coming out of the parser
- Entity does not exist error message is now correctly pluralized