### PR TITLE
bugfixes

### DIFF
--- a/Controller.py
+++ b/Controller.py
@@ -227,8 +227,8 @@ class Controller:
                 cmd = CE.InvalidFlagError(flag, command)
 
         elif "help" == command:
-            if flag != None:
-                cmd = CE.InvalidFlagError(flag)
+            if len(flag) != 0:
+                cmd = CE.InvalidFlagError(flag, command)
             else:
                 cmd = Help.help
 


### PR DESCRIPTION
- the exception that was thrown when help was given invalid flags was missing a parameter
- the condition checking to make sure that the help command was valid always returned false