### PR TITLE
Bugfixes

### DIFF
--- a/Controller.py
+++ b/Controller.py
@@ -67,6 +67,8 @@ class Controller:
             
             except TypeError as t:
                 Output.write(CE.InvalidArgCountError(t))
+            except ValueError as v:
+                Output.write(CE.NeedsMoreInput())
             except Exception as e:
                 Output.write(str(e))
             
@@ -135,6 +137,10 @@ class Controller:
                 With invalid flag: CustomExceptions.InvalidFlagError
                 With invalid command: CustomExceptions.CommandNotFoundError
         '''
+        #guarding no input saves resources
+        if not input: 
+            raise CE.NoInputError()
+        
         #actual input to be parsed, split on spaces
         bits = input.split()
 

--- a/CustomExceptions.py
+++ b/CustomExceptions.py
@@ -141,6 +141,20 @@ class CustomExceptions:
         '''
         def __init__(self):
             super().__init__(f"This command requires additional input. Type 'help' for command usage.")
+
+    class NoInputError(Error):
+        '''
+            Exception raised when no input is given and enter is hit
+        '''
+        def __init__(self):
+            super().__init__(f"")
+
+    class NeedsMoreInput(Error):
+        '''
+            Exception raised when user gives only a command name
+        '''
+        def __init__(self):
+            super().__init__(f"This command requires more input. Please try again or type 'help' for command usage.")
     #===============================================================================
                                 #I/O Exceptions
     #===============================================================================


### PR DESCRIPTION
- typing a valid command name with no other input now returns a useful message
- leaving the line blank and hitting enter no longer prints an error

Known bugs:
- sometimes the invalid argcount error displays the wrong arg count. This is because self is included in the arg count despite not mattering to the user. This will be changed eventually.